### PR TITLE
fix issue with sonar.properties for maven build

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 K. Siva Prasad Reddy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/generators/server/templates/app/sonar-project.properties
+++ b/generators/server/templates/app/sonar-project.properties
@@ -11,11 +11,14 @@ sonar.java.codeCoveragePlugin=jacoco
 <%_ if (buildTool === 'maven') { _%>
 sonar.coverage.jacoco.xmlReportPaths=target/jacoco/test/jacoco.xml,target/jacoco/integrationTest/jacoco.xml
 sonar.junit.reportPaths=target/test-results/test,target/test-results/integrationTest
+sonar.java.checkstyle.reportPaths=target/checkstyle-result.xml
+sonar.java.pmd.reportPaths=target/pmd.xml
 <%_ } _%>
 <%_ if (buildTool === 'gradle') { _%>
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
 sonar.junit.reportPaths=build/test-results/test,build/test-results/integrationTest
-<%_ } _%>
 sonar.java.checkstyle.reportPaths=build/reports/checkstyle/main.xml
 sonar.java.pmd.reportPaths=build/reports/pmd/main.xml
 sonar.java.spotbugs.reportPaths=build/reports/spotbugs/main.html
+<%_ } _%>
+


### PR DESCRIPTION
fixes #32 

In maven build if there are spotless issues we can't proceed further hence ignoring that property