### PR TITLE
adds servers Item for running remotely

### DIFF
--- a/generators/server/templates/app/src/main/java/config/SwaggerConfig.java
+++ b/generators/server/templates/app/src/main/java/config/SwaggerConfig.java
@@ -2,17 +2,11 @@ package <%= packageName %>.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.servers.Server;
-import org.springframework.context.annotation.Bean;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@OpenAPIDefinition(info = @Info(title = "<%= appName %>", version = "v1"))
-public class SwaggerConfig {
-
-    @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI().addServersItem(new Server().url("/"));
-    }
-}
+@Configuration(proxyBeanMethods = false)
+@OpenAPIDefinition(
+        info = @Info(title = "aws-dynamodb-project", version = "v1"),
+        servers = @Server(url = "/"))
+public class SwaggerConfig {}

--- a/generators/server/templates/app/src/main/java/config/SwaggerConfig.java
+++ b/generators/server/templates/app/src/main/java/config/SwaggerConfig.java
@@ -2,8 +2,17 @@ package <%= packageName %>.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @OpenAPIDefinition(info = @Info(title = "<%= appName %>", version = "v1"))
-public class SwaggerConfig {}
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI().addServersItem(new Server().url("/"));
+    }
+}

--- a/generators/server/templates/app/src/main/java/config/SwaggerConfig.java
+++ b/generators/server/templates/app/src/main/java/config/SwaggerConfig.java
@@ -7,6 +7,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 @OpenAPIDefinition(
-        info = @Info(title = "aws-dynamodb-project", version = "v1"),
+        info = @Info(title = "<%= appName %>", version = "v1"),
         servers = @Server(url = "/"))
 public class SwaggerConfig {}


### PR DESCRIPTION
Adding servers information allows user to run with both http and https  scheme especially when working in remote development like gitpod