### PR TITLE
fixes issue with mysql and mariadb when flyway is selected

### DIFF
--- a/generators/server/templates/gradle/build.gradle
+++ b/generators/server/templates/gradle/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     <%_ if (dbMigrationTool  === 'flywaydb') { _%>
     implementation 'org.flywaydb:flyway-core'
     <%_ } _%>
+    <%_ if (dbMigrationTool  === 'flywaydb' && (databaseType === 'mysql' || databaseType === 'mariadb')) { _%>
+    implementation 'org.flywaydb:flyway-mysql'
+    <%_ } _%>
     <%_ if (dbMigrationTool === 'liquibase') { _%>
     implementation 'org.liquibase:liquibase-core'
     <%_ } _%>

--- a/generators/server/templates/maven/pom.xml
+++ b/generators/server/templates/maven/pom.xml
@@ -136,7 +136,7 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
         <%_ } _%>
-        <%_ if (databaseType === 'mysql' || databaseType === 'mariadb') { _%>
+        <%_ if (dbMigrationTool  === 'flywaydb' && (databaseType === 'mysql' || databaseType === 'mariadb')) { _%>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-mysql</artifactId>


### PR DESCRIPTION
Currently In gradle version when mysql or mariadb is selected as database and flyway as migration tool `flyway-mysql` dependency is not added.

For Maven build, when mysql or mariadb is selected as database and liquibase as migration tool `flyway-mysql` dependency is added which shouldn't be added .

This PR fixes both issues