### PR TITLE
adds backward compatibility and fixes duplicate id issue

### DIFF
--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.sql
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.sql
@@ -1,5 +1,5 @@
 -- liquibase formatted sql
--- changeset author:author id:createTable-<% tableName %>
+-- changeset author:app id:createTable-<% tableName %>
 -- see https://docs.liquibase.com/concepts/changelogs/sql-format.html
 
 create table <%= tableName %> (

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.sql
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.sql
@@ -1,5 +1,5 @@
 -- liquibase formatted sql
--- changeset author:author id:001-init
+-- changeset author:app id:createTable-<% tableName %>
 -- see https://docs.liquibase.com/concepts/changelogs/sql-format.html
 
 create sequence <%= tableName %>_seq start with 1 increment by 50;

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -236,7 +236,7 @@ module.exports = class extends BaseGenerator {
         }
 
         if(configOptions.dbMigrationTool === 'liquibase') {
-            const dbFmt = configOptions.dbMigrationFormat;
+            const dbFmt = configOptions.dbMigrationFormat || 'xml';
             const resTemplates = [
                 {src: 'db/migration/liquibase/changelog/db.changelog-master.yaml', dest: 'db/changelog/db.changelog-master.yaml'},
                 {src: `db/migration/liquibase/changelog/01-init.${dbFmt}`, dest: `db/changelog/migration/01-init.${dbFmt}`},


### PR DESCRIPTION
When attempting to use generator project in old, generated projects it is causing issue as Liquibase format is introduced later, to fix this made xml as default value.

When Liquibase sql format is chosen and generating multiple entities is causing duplicate id issue. fixed this