### PR TITLE
set log file name

### DIFF
--- a/generators/server/templates/app/src/main/resources/application.properties
+++ b/generators/server/templates/app/src/main/resources/application.properties
@@ -5,7 +5,6 @@ spring.main.allow-bean-definition-overriding=true
 spring.jmx.enabled=false
 spring.mvc.problemdetails.enabled=true
 
-
 ################ Actuator #####################
 management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,metrics,prometheus
 management.endpoint.health.show-details=always

--- a/generators/server/templates/app/src/main/resources/application.properties
+++ b/generators/server/templates/app/src/main/resources/application.properties
@@ -5,6 +5,9 @@ spring.main.allow-bean-definition-overriding=true
 spring.jmx.enabled=false
 spring.mvc.problemdetails.enabled=true
 
+################ Logging #####################
+logging.file.name=logs/${spring.application.name}.log
+
 ################ Actuator #####################
 management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,metrics,prometheus
 management.endpoint.health.show-details=always

--- a/generators/server/templates/app/src/main/resources/application.properties
+++ b/generators/server/templates/app/src/main/resources/application.properties
@@ -5,8 +5,6 @@ spring.main.allow-bean-definition-overriding=true
 spring.jmx.enabled=false
 spring.mvc.problemdetails.enabled=true
 
-################ Logging #####################
-logging.file.name=logs/${spring.application.name}.log
 
 ################ Actuator #####################
 management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,metrics,prometheus

--- a/generators/server/templates/app/src/main/resources/logback-spring.xml
+++ b/generators/server/templates/app/src/main/resources/logback-spring.xml
@@ -2,6 +2,8 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml" />
     <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
     <%_ if (features.includes('elk')) { _%>
     <springProperty defaultValue="localhost" name="logstashHost"
     scope="context" source="application.logstash-host"/>
@@ -45,6 +47,7 @@
         </root>
     </springProfile>
     <springProfile name="!default">
+        <property name="LOG_FILE" value="logs/${appName}.log"/>
         <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
         <root level="INFO">
             <appender-ref ref="FILE" />


### PR DESCRIPTION
In the current setup of `logback-spring.xml` we are not setting the logfile name, hence we should set it using application.properties