### PR TITLE
using text as column for postgresql tables

### DIFF
--- a/generators/controller/templates/app/src/main/resources/db/migration/flyway/V1__new_table_no_seq.sql
+++ b/generators/controller/templates/app/src/main/resources/db/migration/flyway/V1__new_table_no_seq.sql
@@ -1,5 +1,10 @@
 create table <%= tableName %> (
     id bigint not null auto_increment,
+    <%_ if (databaseType != 'postgresql') { _%>
     text varchar(1024) not null,
+    <%_ } _%>
+    <%_ if (databaseType === 'postgresql') { _%>
+    text text not null,
+    <%_ } _%>
     primary key (id)
 );

--- a/generators/controller/templates/app/src/main/resources/db/migration/flyway/V1__new_table_with_seq.sql
+++ b/generators/controller/templates/app/src/main/resources/db/migration/flyway/V1__new_table_with_seq.sql
@@ -7,6 +7,11 @@ create table <%= tableName %> (
     <%_ if (databaseType === 'mariadb') { _%>
     id bigint DEFAULT nextval(`<%= tableName %>_seq`) not null,
     <%_ } _%>
+    <%_ if (databaseType != 'postgresql') { _%>
     text varchar(1024) not null,
+    <%_ } _%>
+    <%_ if (databaseType === 'postgresql') { _%>
+    text text not null,
+    <%_ } _%>
     primary key (id)
 );

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.sql
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.sql
@@ -4,6 +4,11 @@
 
 create table <%= tableName %> (
     id bigint not null auto_increment,
+    <%_ if (databaseType != 'postgresql') { _%>
     text varchar(1024) not null,
+    <%_ } _%>
+    <%_ if (databaseType === 'postgresql') { _%>
+    text text not null,
+    <%_ } _%>
     primary key (id)
 );

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.xml
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.xml
@@ -4,14 +4,18 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <property  name="string.type"  value="varchar(255)"  dbms="!postgresql"/>
+    <property  name="string.type"  value="text"  dbms="postgresql"/>
+
     <changeSet author="app" id="createTable-<%= tableName %>">
 
         <createTable tableName="<%= tableName %>">
             <column name="id" type="bigint" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="text" type="varchar(1024)">
+            <column name="text" type="${string.type}">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.yaml
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_no_seq.yaml
@@ -1,5 +1,13 @@
 # https://docs.liquibase.com/concepts/changelogs/yaml-format.html
 databaseChangeLog:
+  -  property:
+       dbms:  postgresql
+       name:  string.type
+       value:  text
+  -  property:
+       dbms:  "!postgresql"
+       name:  string.type
+       value:  varchar(255)
   - changeSet:
       author: author
       id: createTable-<%= tableName %>
@@ -16,6 +24,6 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: text
-                  type: varchar(1024)
+                  type: ${string.type}
                   constraints:
                     nullable: false

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.sql
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.sql
@@ -11,6 +11,11 @@ create table <%= tableName %> (
     <%_ if (databaseType === 'mariadb') { _%>
     id bigint DEFAULT nextval(`<%= tableName %>_seq`) not null,
     <%_ } _%>
+    <%_ if (databaseType != 'postgresql') { _%>
     text varchar(1024) not null,
+    <%_ } _%>
+    <%_ if (databaseType === 'postgresql') { _%>
+    text text not null,
+    <%_ } _%>
     primary key (id)
 );

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.xml
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.xml
@@ -4,7 +4,11 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <property  name="string.type"  value="varchar(255)"  dbms="!postgresql"/>
+    <property  name="string.type"  value="text"  dbms="postgresql"/>
+
     <changeSet author="app" id="createTable-<%= tableName %>">
         <createSequence
                         sequenceName="<%= tableName %>_seq"
@@ -15,7 +19,7 @@
             <column name="id" type="bigint" defaultValueSequenceNext="<%= tableName %>_seq">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="text" type="varchar(1024)">
+            <column name="text" type="${string.type}">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.yaml
+++ b/generators/controller/templates/app/src/main/resources/db/migration/liquibase/changelog/01-new_table_with_seq.yaml
@@ -1,5 +1,13 @@
 # https://docs.liquibase.com/concepts/changelogs/yaml-format.html
 databaseChangeLog:
+  -  property:
+       dbms:  postgresql
+       name:  string.type
+       value:  text
+  -  property:
+       dbms:  "!postgresql"
+       name:  string.type
+       value:  varchar(255)
   - changeSet:
       author: author
       id: createTable-<%= tableName %>
@@ -20,6 +28,6 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: text
-                  type: varchar(1024)
+                  type: ${string.type}
                   constraints:
                     nullable: false


### PR DESCRIPTION
as per good practices of postgres we should declare the data type as `text`

This change address the issue